### PR TITLE
Prevent fractions of thumbnails.

### DIFF
--- a/SAVideoRangeSlider/SAVideoRangeSlider.m
+++ b/SAVideoRangeSlider/SAVideoRangeSlider.m
@@ -337,7 +337,11 @@
         self.imageGenerator.maximumSize = CGSizeMake(_bgView.frame.size.width, _bgView.frame.size.height);
     }
     
-    int picWidth = 20;
+    //If you'd rather specify the number of pics, just set picsCnt manually
+    int picWidth = 40;
+    int picsCnt = ceil(_bgView.frame.size.width / picWidth);
+    picWidth = _bgView.frame.size.width / picsCnt;
+    int remainderWidth = _bgView.frame.size.width - (picsCnt * picWidth);
     
     // First image
     NSError *error;
@@ -362,17 +366,23 @@
     
     _durationSeconds = CMTimeGetSeconds([myAsset duration]);
     
-    int picsCnt = ceil(_bgView.frame.size.width / picWidth);
     
     NSMutableArray *allTimes = [[NSMutableArray alloc] init];
     
     int time4Pic = 0;
+    int frameOrigin = picWidth;
     
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0){
         // Bug iOS7 - generateCGImagesAsynchronouslyForTimes
         int prefreWidth=0;
         for (int i=1, ii=1; i<picsCnt; i++){
-            time4Pic = i*picWidth;
+            int thisPicWidth = picWidth;
+            if (remainderWidth > 0)
+            {
+                thisPicWidth++;
+                remainderWidth--;
+            }
+            time4Pic = frameOrigin;
             
             CMTime timeFrame = CMTimeMakeWithSeconds(_durationSeconds*time4Pic/_bgView.frame.size.width, 600);
             
@@ -395,21 +405,12 @@
             
             
             CGRect currentFrame = tmp.frame;
-            currentFrame.origin.x = ii*picWidth;
-
-            currentFrame.size.width=picWidth;
-            prefreWidth+=currentFrame.size.width;
+            currentFrame.origin.x = frameOrigin;
+            frameOrigin += thisPicWidth;
             
-            if( i == picsCnt-1){
-                currentFrame.size.width-=6;
-            }
+            currentFrame.size.width = thisPicWidth;
+            prefreWidth += currentFrame.size.width;
             tmp.frame = currentFrame;
-            int all = (ii+1)*tmp.frame.size.width;
-
-            if (all > _bgView.frame.size.width){
-                int delta = all - _bgView.frame.size.width;
-                currentFrame.size.width -= delta;
-            }
 
             ii++;
             

--- a/SAVideoRangeSlider/SAVideoRangeSlider.m
+++ b/SAVideoRangeSlider/SAVideoRangeSlider.m
@@ -374,7 +374,6 @@
     
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0){
         // Bug iOS7 - generateCGImagesAsynchronouslyForTimes
-        int prefreWidth=0;
         for (int i=1, ii=1; i<picsCnt; i++){
             int thisPicWidth = picWidth;
             if (remainderWidth > 0)
@@ -409,7 +408,6 @@
             frameOrigin += thisPicWidth;
             
             currentFrame.size.width = thisPicWidth;
-            prefreWidth += currentFrame.size.width;
             tmp.frame = currentFrame;
 
             ii++;

--- a/SAVideoRangeSlider/SAVideoRangeSlider.m
+++ b/SAVideoRangeSlider/SAVideoRangeSlider.m
@@ -338,7 +338,7 @@
     }
     
     //If you'd rather specify the number of pics, just set picsCnt manually
-    int picWidth = 40;
+    int picWidth = 20;
     int picsCnt = ceil(_bgView.frame.size.width / picWidth);
     picWidth = _bgView.frame.size.width / picsCnt;
     int remainderWidth = _bgView.frame.size.width - (picsCnt * picWidth);


### PR DESCRIPTION
The fractional thumbnail on the right end of the bar was really bugging me, so I set out to try and prevent fractional thumbnails by calculating the closest width necessary to perfectly fit the thumbnails into the bar. Some thumbnails will end up with a picWidth +1 larger than others to make up for fractions. This works regardless of what picWidth you set.

Old bar with fractional thumbnail on the end (screen taken from readme.md)
![savideorangeslider0](https://cloud.githubusercontent.com/assets/7243883/7889866/e9c77cf6-0607-11e5-97f1-4d90cfe830c0.png)

New bar with no fractional thumbnails
![savideorangeslider1](https://cloud.githubusercontent.com/assets/7243883/7889889/0c520976-0608-11e5-8f9c-5af474491f2b.png)
![savideorangeslider2](https://cloud.githubusercontent.com/assets/7243883/7889892/0eab9fb6-0608-11e5-9e1a-7c3a39d29aa2.png)
![savideorangeslider3](https://cloud.githubusercontent.com/assets/7243883/7890106/6017647e-0609-11e5-8f0a-cd1439bcc35b.png)

(note the difference in bar lengths is just due to how the screenshots were taken. It's not from any changes in the code)
